### PR TITLE
Plans status

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,18 @@ Atualizar informações do plano:
 Moip::Assinaturas::Plan.update(plan_attributes)
 ```
 
+Desativar um plano:
+
+```ruby
+Moip::Assinaturas::Plan.inactivate(plan_code)
+```
+
+Ativar um plano:
+
+```ruby
+Moip::Assinaturas::Plan.activate(plan_code)
+```
+
 ## Clientes
 
 Criar um novo cliente:

--- a/lib/moip-assinaturas/client.rb
+++ b/lib/moip-assinaturas/client.rb
@@ -47,6 +47,16 @@ module Moip::Assinaturas
         peform_action!(:put, "/plans/#{plan[:code]}", opts, true)
       end
 
+      def inactivate_plan(code, opts={})
+        prepare_options(opts, { headers: { 'Content-Type' => 'application/json' } })
+        peform_action!(:put, "/plans/#{code}/suspend", opts, true)
+      end
+
+      def activate_plan(code, opts={})
+        prepare_options(opts, { headers: { 'Content-Type' => 'application/json' } })
+        peform_action!(:put, "/plans/#{code}/activate", opts, true)
+      end
+
       def create_customer(customer, new_vault, opts={})
         prepare_options(opts, { body: customer.to_json, headers: { 'Content-Type' => 'application/json' } })
         peform_action!(:post, "/customers?new_vault=#{new_vault}", opts)

--- a/lib/moip-assinaturas/client.rb
+++ b/lib/moip-assinaturas/client.rb
@@ -49,7 +49,7 @@ module Moip::Assinaturas
 
       def inactivate_plan(code, opts={})
         prepare_options(opts, { headers: { 'Content-Type' => 'application/json' } })
-        peform_action!(:put, "/plans/#{code}/suspend", opts, true)
+        peform_action!(:put, "/plans/#{code}/inactivate", opts, true)
       end
 
       def activate_plan(code, opts={})

--- a/lib/moip-assinaturas/plan.rb
+++ b/lib/moip-assinaturas/plan.rb
@@ -66,13 +66,49 @@ module Moip::Assinaturas
 
         case response.code
         when 200
-          return {
-            success: true
-          }
+          return { success: true }
         when 400
           return {
             success: false,
             plan: hash
+          }
+        else
+          raise(WebServerResponseError, "Ocorreu um erro no retorno do webservice")
+        end
+      end
+
+      def inactivate(code, opts={})
+        response = Moip::Assinaturas::Client.inactivate_plan(code, opts)
+        hash     = JSON.load(response.body)
+        hash     = hash ? hash.with_indifferent_access : {}
+
+        case response.code
+        when 200
+          return { success: true }
+        when 400
+          return {
+            success: false,
+            message: hash[:message],
+            errors:  hash[:errors]
+          }
+        else
+          raise(WebServerResponseError, "Ocorreu um erro no retorno do webservice")
+        end
+      end
+
+      def activate(code, opts={})
+        response = Moip::Assinaturas::Client.activate_plan(code, opts)
+        hash     = JSON.load(response.body)
+        hash     = hash ? hash.with_indifferent_access : {}
+
+        case response.code
+        when 200
+          return { success: true }
+        when 400
+          return {
+            success: false,
+            message: hash[:message],
+            errors:  hash[:errors]
           }
         else
           raise(WebServerResponseError, "Ocorreu um erro no retorno do webservice")

--- a/spec/moip-assinaturas/plan_spec.rb
+++ b/spec/moip-assinaturas/plan_spec.rb
@@ -128,6 +128,16 @@ describe Moip::Assinaturas::Plan do
       request[:success].should      be_falsey
       request[:message].should  == 'not found'
     end
+
+    it "should inactivate a plan" do
+      request = Moip::Assinaturas::Plan.inactivate("plano02")
+      request[:success].should be_truthy
+    end
+
+    it "should reactive a plan" do
+      request = Moip::Assinaturas::Plan.activate("plano02")
+      request[:success].should be_truthy
+    end
   end
 
   it "should update an existing plan" do

--- a/spec/moip-assinaturas/plan_spec.rb
+++ b/spec/moip-assinaturas/plan_spec.rb
@@ -102,6 +102,20 @@ describe Moip::Assinaturas::Plan do
       body:   "",
       status: [200, 'OK']
     )
+
+    FakeWeb.register_uri(
+      :put,
+      "https://TOKEN:KEY@api.moip.com.br/assinaturas/v1/plans/plano02/activate",
+      body: '',
+      status: [200, 'OK']
+    )
+
+    FakeWeb.register_uri(
+      :put,
+      "https://TOKEN:KEY@api.moip.com.br/assinaturas/v1/plans/plano02/inactivate",
+      body: '',
+      status: [200, 'OK']
+    )
   end
 
   it "should can create a new plan" do

--- a/spec/moip-assinaturas/subscription_spec.rb
+++ b/spec/moip-assinaturas/subscription_spec.rb
@@ -52,7 +52,7 @@ describe Moip::Assinaturas::Subscription do
       "https://TOKEN:KEY@api.moip.com.br/assinaturas/v1/subscriptions?filters=status::eq(ACTIVE)",
       body:   File.join(File.dirname(__FILE__), '..', 'fixtures', 'list_subscriptions_queried.json'),
       status: [200, 'OK']
-    )    
+    )
 
     FakeWeb.register_uri(
       :get,
@@ -191,11 +191,6 @@ describe Moip::Assinaturas::Subscription do
 
   it "should reactive a subscription" do
     request = Moip::Assinaturas::Subscription.activate('assinatura1')
-    request[:success].should be_truthy
-  end
-
-  it "should suspend a subscription" do
-    request = Moip::Assinaturas::Subscription.suspend('assinatura1')
     request[:success].should be_truthy
   end
 


### PR DESCRIPTION
## Plans activate/inactivate

Criação de _def_s para alterar o Status de um Plano entre ativo e inativo a partir do _code_, da mesma forma que foi feita em Subscriptions.
