### PR TITLE
Add generation of new bank slip for an invoice

### DIFF
--- a/lib/moip-assinaturas/client.rb
+++ b/lib/moip-assinaturas/client.rb
@@ -137,6 +137,11 @@ module Moip::Assinaturas
         peform_action!(:post, "/invoices/#{id}/retry", opts, true)
       end
 
+      def generate_invoice_slip(invoice_id, opts = {})
+        prepare_options(opts, { headers: { 'Content-Type' => 'application/json' } })
+        peform_action!(:post, "/invoices/#{invoice_id}/boletos", opts, true)
+      end
+
       def list_payments(invoice_id, opts={})
         prepare_options(opts, { headers: { 'Content-Type' => 'application/json' } })
         peform_action!(:get, "/invoices/#{invoice_id}/payments", opts, true)

--- a/lib/moip-assinaturas/invoice.rb
+++ b/lib/moip-assinaturas/invoice.rb
@@ -60,6 +60,33 @@ module Moip::Assinaturas
         end
       end
 
+      def generate_slip(id, opts = {})
+        response = Moip::Assinaturas::Client.generate_invoice_slip(id, opts)
+        hash     = JSON.load response.body
+        hash     = hash.with_indifferent_access if hash
+
+        case response.code
+        when 200
+          return {
+            success:  true,
+            bank_slip: hash
+          }
+        when 400
+          return {
+            success: false,
+            message: hash['message'],
+            errors:  hash['errors']
+          }
+        when 404
+          return {
+            success: false,
+            message: 'not found'
+          }
+        else
+          raise(WebServerResponseError, "Ocorreu um erro no retorno do webservice")
+        end
+      end
+
       def notify(invoice_id, opts = {})
         response = Moip::Assinaturas::Client.notify_invoice(invoice_id, opts)
         hash     = JSON.load(response.body)

--- a/spec/fixtures/generate_bank_slip.json
+++ b/spec/fixtures/generate_bank_slip.json
@@ -1,0 +1,50 @@
+{
+  "subscription_code": "assinatura_boleto",
+  "amount": 100,
+  "_links": {
+    "boleto": {
+      "redirect_href": "https://checkout-sandbox.moip.com.br/boleto/PAY-S4YWH31TW8E8"
+    }
+  },
+  "due_date": {
+    "month": 8,
+    "hour": 0,
+    "year": 2020,
+    "day": 1,
+    "minute": 0,
+    "second": 0
+  },
+  "id": 4583997,
+  "creation_date": {
+    "month": 8,
+    "hour": 10,
+    "year": 2017,
+    "day": 18,
+    "minute": 52,
+    "second": 24
+  },
+  "occurrence": 1,
+  "plan": {
+    "code": "13443245",
+    "name": "Plan Name"
+  },
+  "items": [
+    {
+      "amount": 100,
+      "type": "Subscription Fee"
+    },
+    {
+      "amount": 0,
+      "type": "Hiring Fee"
+    }
+  ],
+  "customer": {
+    "code": "customer_code",
+    "fullname": "José Silva",
+    "email": "josesilva@email.com"
+  },
+  "status": {
+    "code": 2,
+    "description": "Aguardando confirmação"
+  }
+}

--- a/spec/moip-assinaturas/invoice_spec.rb
+++ b/spec/moip-assinaturas/invoice_spec.rb
@@ -68,6 +68,20 @@ describe Moip::Assinaturas::Invoice do
       status: [404, 'not found']
     )
 
+    FakeWeb.register_uri(
+      :post,
+      "https://TOKEN:KEY@api.moip.com.br/assinaturas/v1/invoices/INV-998889/boletos",
+      body:  File.join(File.dirname(__FILE__), '..', 'fixtures', 'generate_bank_slip.json'),
+      status: [200, 'OK']
+    )
+
+    FakeWeb.register_uri(
+      :post,
+      "https://TOKEN:KEY@api.moip.com.br/assinaturas/v1/invoices/INV-998879/boletos",
+      body:  '',
+      status: [404, 'not found']
+    )
+
   end
 
   it "should list all invoices from a subscription" do
@@ -97,6 +111,21 @@ describe Moip::Assinaturas::Invoice do
 
     it "should not retry Invoice" do
       request = Moip::Assinaturas::Invoice.retry "INV-998779"
+      expect(request[:success]).to be_falsey
+    end
+  end
+
+  context "generate new invoice bank slip" do
+    it "should generate bank slip" do
+      request = Moip::Assinaturas::Invoice.generate_slip "INV-998889", { day: 1, month: 8, year: 2020 }
+      expect(request[:success]).to be_truthy
+      expect(request[:bank_slip][:due_date][:day]).to eq 1
+      expect(request[:bank_slip][:due_date][:month]).to eq 8
+      expect(request[:bank_slip][:due_date][:year]).to eq 2020
+    end
+
+    it "should not generate bank slip" do
+      request = Moip::Assinaturas::Invoice.generate_slip "INV-998879"
       expect(request[:success]).to be_falsey
     end
   end


### PR DESCRIPTION
- [x] Add generation of new bank slip for an invoice, using https://dev.moip.com.br/v1.5/reference#retentativa-de-pagamento-de-uma-fatura-por-boleto